### PR TITLE
Add Scala 3 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.6, 2.12.14]
+        scala: [2.13.6, 2.12.14, 3.0.1]
         java: [adopt@1.8, adopt@1.11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -116,6 +116,16 @@ jobs:
           name: target-${{ matrix.os }}-2.12.14-${{ matrix.java }}
 
       - name: Inflate target directories (2.12.14)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.0.1)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-3.0.1-${{ matrix.java }}
+
+      - name: Inflate target directories (3.0.1)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/ci-release.sbt
+++ b/ci-release.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := Dependencies.Versions.scala3
+ThisBuild / scalaVersion := Dependencies.Versions.scala213
 ThisBuild / crossScalaVersions := Seq(
   Dependencies.Versions.scala213,
   Dependencies.Versions.scala212,

--- a/ci-release.sbt
+++ b/ci-release.sbt
@@ -1,5 +1,9 @@
-ThisBuild / scalaVersion := Dependencies.Versions.scala213
-ThisBuild / crossScalaVersions := Seq(Dependencies.Versions.scala213, Dependencies.Versions.scala212)
+ThisBuild / scalaVersion := Dependencies.Versions.scala3
+ThisBuild / crossScalaVersions := Seq(
+  Dependencies.Versions.scala213,
+  Dependencies.Versions.scala212,
+  Dependencies.Versions.scala3
+)
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@1.11")
 

--- a/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/ClientCtxSyntaxSpec.scala
+++ b/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/ClientCtxSyntaxSpec.scala
@@ -2,7 +2,6 @@ package io.janstenpickle.trace4cats.http4s.client
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.{~>, Id}
 import io.janstenpickle.trace4cats.ToHeaders
 import io.janstenpickle.trace4cats.http4s.client.syntax._
 import io.janstenpickle.trace4cats.http4s.client.Instances._

--- a/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/ClientCtxSyntaxSpec.scala
+++ b/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/ClientCtxSyntaxSpec.scala
@@ -6,11 +6,11 @@ import cats.{~>, Id}
 import io.janstenpickle.trace4cats.ToHeaders
 import io.janstenpickle.trace4cats.http4s.client.syntax._
 import io.janstenpickle.trace4cats.http4s.client.Instances._
-import io.janstenpickle.trace4cats.http4s.common.TraceContext
+import io.janstenpickle.trace4cats.http4s.common._
 
 class ClientCtxSyntaxSpec
     extends BaseClientTracerSpec[IO, Kleisli[IO, TraceContext[IO], *], TraceContext[IO]](
-      λ[IO ~> Id](_.unsafeRunSync()),
+      RunIOToId,
       TraceContext("3d86cad5-d321-448f-a758-d28714fc1045", _),
       _.liftTraceContext(spanLens = TraceContext.span[IO], headersGetter = TraceContext.headers[IO](ToHeaders.all))
     )

--- a/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/ClientSyntaxSpec.scala
+++ b/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/ClientSyntaxSpec.scala
@@ -2,10 +2,8 @@ package io.janstenpickle.trace4cats.http4s.client
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.{~>, Id}
 import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.http4s.client.syntax._
-import io.janstenpickle.trace4cats.http4s.client.Instances._
 import io.janstenpickle.trace4cats.http4s.common.RunIOToId
 
 class ClientSyntaxSpec

--- a/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/ClientSyntaxSpec.scala
+++ b/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/ClientSyntaxSpec.scala
@@ -6,10 +6,7 @@ import cats.{~>, Id}
 import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.http4s.client.syntax._
 import io.janstenpickle.trace4cats.http4s.client.Instances._
+import io.janstenpickle.trace4cats.http4s.common.RunIOToId
 
 class ClientSyntaxSpec
-    extends BaseClientTracerSpec[IO, Kleisli[IO, Span[IO], *], Span[IO]](
-      λ[IO ~> Id](_.unsafeRunSync()),
-      identity,
-      _.liftTrace()
-    )
+    extends BaseClientTracerSpec[IO, Kleisli[IO, Span[IO], *], Span[IO]](RunIOToId, identity, _.liftTrace())

--- a/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/Instances.scala
+++ b/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/Instances.scala
@@ -2,7 +2,6 @@ package io.janstenpickle.trace4cats.http4s.client
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.base.context.Local
 import io.janstenpickle.trace4cats.http4s.common.{CommonInstances, TraceContext}

--- a/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/Instances.scala
+++ b/modules/http4s-client/src/test/scala/io/janstenpickle/trace4cats/http4s/client/Instances.scala
@@ -5,10 +5,9 @@ import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.base.context.Local
-import io.janstenpickle.trace4cats.http4s.common.TraceContext
+import io.janstenpickle.trace4cats.http4s.common.{CommonInstances, TraceContext}
 
-object Instances {
+object Instances extends CommonInstances {
   implicit val localSpan: Local[Kleisli[IO, TraceContext[IO], *], Span[IO]] =
     Local[Kleisli[IO, TraceContext[IO], *], TraceContext[IO]].focus(TraceContext.span[IO])
-  implicit val runtime: IORuntime = IORuntime.global
 }

--- a/modules/http4s-common/src/test/scala/io/janstenpickle/trace4cats/http4s/common/CommonInstances.scala
+++ b/modules/http4s-common/src/test/scala/io/janstenpickle/trace4cats/http4s/common/CommonInstances.scala
@@ -1,0 +1,9 @@
+package io.janstenpickle.trace4cats.http4s.common
+
+import cats.effect.unsafe.IORuntime
+
+trait CommonInstances {
+  implicit val runtime: IORuntime = IORuntime.global
+}
+
+object CommonInstances extends CommonInstances

--- a/modules/http4s-common/src/test/scala/io/janstenpickle/trace4cats/http4s/common/Http4sHeadersConverterSpec.scala
+++ b/modules/http4s-common/src/test/scala/io/janstenpickle/trace4cats/http4s/common/Http4sHeadersConverterSpec.scala
@@ -11,7 +11,7 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 class Http4sHeadersConverterSpec extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks with ArbitraryInstances {
   behavior.of("Http4sHeaders.converter")
 
-  it should "convert headers isomorphically" in forAll { traceHeaders: TraceHeaders =>
+  it should "convert headers isomorphically" in forAll { (traceHeaders: TraceHeaders) =>
     assert(Eq.eqv(traceHeaders, converter.from(converter.to(traceHeaders))))
   }
 

--- a/modules/http4s-common/src/test/scala/io/janstenpickle/trace4cats/http4s/common/RunIOToId.scala
+++ b/modules/http4s-common/src/test/scala/io/janstenpickle/trace4cats/http4s/common/RunIOToId.scala
@@ -1,0 +1,9 @@
+package io.janstenpickle.trace4cats.http4s.common
+
+import cats.{~>, Id}
+import cats.effect.IO
+import io.janstenpickle.trace4cats.http4s.common.CommonInstances._
+
+object RunIOToId extends ~>[IO, Id] {
+  override def apply[A](fa: IO[A]): Id[A] = fa.unsafeRunSync()
+}

--- a/modules/http4s-common/src/test/scala/io/janstenpickle/trace4cats/http4s/common/RunIOToId.scala
+++ b/modules/http4s-common/src/test/scala/io/janstenpickle/trace4cats/http4s/common/RunIOToId.scala
@@ -4,6 +4,6 @@ import cats.{~>, Id}
 import cats.effect.IO
 import io.janstenpickle.trace4cats.http4s.common.CommonInstances._
 
-object RunIOToId extends ~>[IO, Id] {
-  override def apply[A](fa: IO[A]): Id[A] = fa.unsafeRunSync()
+object RunIOToId extends (IO ~> Id) {
+  def apply[A](fa: IO[A]): Id[A] = fa.unsafeRunSync()
 }

--- a/modules/http4s-common/src/test/scala/io/janstenpickle/trace4cats/http4s/common/RunKleisliWithEmptyTraceContext.scala
+++ b/modules/http4s-common/src/test/scala/io/janstenpickle/trace4cats/http4s/common/RunKleisliWithEmptyTraceContext.scala
@@ -1,0 +1,9 @@
+package io.janstenpickle.trace4cats.http4s.common
+
+import cats.data.Kleisli
+import cats.effect.IO
+import cats.~>
+
+object RunKleisliWithEmptyTraceContext extends (Kleisli[IO, TraceContext[IO], *] ~> IO) {
+  def apply[A](fa: Kleisli[IO, TraceContext[IO], A]): IO[A] = TraceContext.empty[IO].flatMap(fa.run)
+}

--- a/modules/http4s-common/src/test/scala/io/janstenpickle/trace4cats/http4s/common/RunKleisliWithNoopSpan.scala
+++ b/modules/http4s-common/src/test/scala/io/janstenpickle/trace4cats/http4s/common/RunKleisliWithNoopSpan.scala
@@ -1,0 +1,10 @@
+package io.janstenpickle.trace4cats.http4s.common
+
+import cats.data.Kleisli
+import cats.effect.IO
+import cats.{~>, Id}
+import io.janstenpickle.trace4cats.Span
+
+object RunKleisliWithNoopSpan extends ~>[Kleisli[IO, Span[IO], *], IO] {
+  override def apply[A](fa: Kleisli[IO, Span[IO], A]): IO[A] = Span.noop[IO].use(fa.run)
+}

--- a/modules/http4s-common/src/test/scala/io/janstenpickle/trace4cats/http4s/common/RunKleisliWithNoopSpan.scala
+++ b/modules/http4s-common/src/test/scala/io/janstenpickle/trace4cats/http4s/common/RunKleisliWithNoopSpan.scala
@@ -2,9 +2,9 @@ package io.janstenpickle.trace4cats.http4s.common
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.{~>, Id}
+import cats.~>
 import io.janstenpickle.trace4cats.Span
 
-object RunKleisliWithNoopSpan extends ~>[Kleisli[IO, Span[IO], *], IO] {
-  override def apply[A](fa: Kleisli[IO, Span[IO], A]): IO[A] = Span.noop[IO].use(fa.run)
+object RunKleisliWithNoopSpan extends (Kleisli[IO, Span[IO], *] ~> IO) {
+  def apply[A](fa: Kleisli[IO, Span[IO], A]): IO[A] = Span.noop[IO].use(fa.run)
 }

--- a/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/BaseServerTracerSpec.scala
+++ b/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/BaseServerTracerSpec.scala
@@ -65,7 +65,7 @@ abstract class BaseServerTracerSpec[F[_]: Async, G[_]: Async](
     }
   }
 
-  it should "correctly set span status when the server throws an exception" in forAll { errorMsg: String =>
+  it should "correctly set span status when the server throws an exception" in forAll { (errorMsg: String) =>
     val app = HttpRoutes.of[G] { case GET -> Root =>
       ApplicativeThrow[G].raiseError(new RuntimeException(errorMsg))
     }
@@ -78,7 +78,7 @@ abstract class BaseServerTracerSpec[F[_]: Async, G[_]: Async](
     }
   }
 
-  it should "correctly set the span status from the http response" in forAll { response: G[Response[G]] =>
+  it should "correctly set the span status from the http response" in forAll { (response: G[Response[G]]) =>
     val app = HttpRoutes.of[G] { case GET -> Root =>
       response
     }
@@ -94,7 +94,7 @@ abstract class BaseServerTracerSpec[F[_]: Async, G[_]: Async](
     }
   }
 
-  it should "should filter all requests" in forAll { response: G[Response[G]] =>
+  it should "should filter all requests" in forAll { (response: G[Response[G]]) =>
     val app = HttpRoutes.of[G] { case GET -> Root =>
       response
     }

--- a/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/Instances.scala
+++ b/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/Instances.scala
@@ -2,7 +2,6 @@ package io.janstenpickle.trace4cats.http4s.server
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.effect.unsafe.IORuntime
 import io.janstenpickle.trace4cats.http4s.common.{CommonInstances, TraceContext}
 import io.janstenpickle.trace4cats.inject.Trace
 

--- a/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/Instances.scala
+++ b/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/Instances.scala
@@ -3,11 +3,10 @@ package io.janstenpickle.trace4cats.http4s.server
 import cats.data.Kleisli
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
-import io.janstenpickle.trace4cats.http4s.common.TraceContext
+import io.janstenpickle.trace4cats.http4s.common.{CommonInstances, TraceContext}
 import io.janstenpickle.trace4cats.inject.Trace
 
-object Instances {
+object Instances extends CommonInstances {
   implicit val traceContextTrace: Trace[Kleisli[IO, TraceContext[IO], *]] =
     Trace.kleisliInstance[IO].lens[TraceContext[IO]](_.span, (c, span) => c.copy(span = span))
-  implicit val runtime: IORuntime = IORuntime.global
 }

--- a/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ResourceKleisliServerCtxSyntaxSpec.scala
+++ b/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ResourceKleisliServerCtxSyntaxSpec.scala
@@ -2,17 +2,14 @@ package io.janstenpickle.trace4cats.http4s.server
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.{Id, ~>}
-import io.janstenpickle.trace4cats.http4s.common.{RunIOToId, TraceContext}
-import io.janstenpickle.trace4cats.http4s.server.syntax.*
-import io.janstenpickle.trace4cats.http4s.server.Instances.*
+import io.janstenpickle.trace4cats.http4s.common.{RunIOToId, RunKleisliWithEmptyTraceContext, TraceContext}
+import io.janstenpickle.trace4cats.http4s.server.syntax._
+import io.janstenpickle.trace4cats.http4s.server.Instances._
 
 class ResourceKleisliServerCtxSyntaxSpec
     extends BaseServerTracerSpec[IO, Kleisli[IO, TraceContext[IO], *]](
       RunIOToId,
-      new ~>[Kleisli[IO, TraceContext[IO], *], IO] {
-        override def apply[A](fa: Kleisli[IO, TraceContext[IO], A]): IO[A] = TraceContext.empty[IO].flatMap(fa.run)
-      },
+      RunKleisliWithEmptyTraceContext,
       (routes, filter, ep) =>
         routes.tracedContext(
           Http4sResourceKleislis

--- a/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ResourceKleisliServerCtxSyntaxSpec.scala
+++ b/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ResourceKleisliServerCtxSyntaxSpec.scala
@@ -2,15 +2,17 @@ package io.janstenpickle.trace4cats.http4s.server
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.{~>, Id}
-import io.janstenpickle.trace4cats.http4s.common.TraceContext
-import io.janstenpickle.trace4cats.http4s.server.syntax._
-import io.janstenpickle.trace4cats.http4s.server.Instances._
+import cats.{Id, ~>}
+import io.janstenpickle.trace4cats.http4s.common.{RunIOToId, TraceContext}
+import io.janstenpickle.trace4cats.http4s.server.syntax.*
+import io.janstenpickle.trace4cats.http4s.server.Instances.*
 
 class ResourceKleisliServerCtxSyntaxSpec
     extends BaseServerTracerSpec[IO, Kleisli[IO, TraceContext[IO], *]](
-      λ[IO ~> Id](_.unsafeRunSync()),
-      λ[Kleisli[IO, TraceContext[IO], *] ~> IO](ga => TraceContext.empty[IO].flatMap(ga.run)),
+      RunIOToId,
+      new ~>[Kleisli[IO, TraceContext[IO], *], IO] {
+        override def apply[A](fa: Kleisli[IO, TraceContext[IO], A]): IO[A] = TraceContext.empty[IO].flatMap(fa.run)
+      },
       (routes, filter, ep) =>
         routes.tracedContext(
           Http4sResourceKleislis

--- a/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ResourceKleisliServerSyntaxSpec.scala
+++ b/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ResourceKleisliServerSyntaxSpec.scala
@@ -2,11 +2,9 @@ package io.janstenpickle.trace4cats.http4s.server
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.{Id, ~>}
 import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.http4s.common.{RunIOToId, RunKleisliWithNoopSpan}
-import io.janstenpickle.trace4cats.http4s.server.Instances.*
-import io.janstenpickle.trace4cats.http4s.server.syntax.*
+import io.janstenpickle.trace4cats.http4s.server.syntax._
 
 class ResourceKleisliServerSyntaxSpec
     extends BaseServerTracerSpec[IO, Kleisli[IO, Span[IO], *]](

--- a/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ResourceKleisliServerSyntaxSpec.scala
+++ b/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ResourceKleisliServerSyntaxSpec.scala
@@ -2,15 +2,16 @@ package io.janstenpickle.trace4cats.http4s.server
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.{~>, Id}
+import cats.{Id, ~>}
 import io.janstenpickle.trace4cats.Span
-import io.janstenpickle.trace4cats.http4s.server.Instances._
-import io.janstenpickle.trace4cats.http4s.server.syntax._
+import io.janstenpickle.trace4cats.http4s.common.{RunIOToId, RunKleisliWithNoopSpan}
+import io.janstenpickle.trace4cats.http4s.server.Instances.*
+import io.janstenpickle.trace4cats.http4s.server.syntax.*
 
 class ResourceKleisliServerSyntaxSpec
     extends BaseServerTracerSpec[IO, Kleisli[IO, Span[IO], *]](
-      λ[IO ~> Id](_.unsafeRunSync()),
-      λ[Kleisli[IO, Span[IO], *] ~> IO](ga => Span.noop[IO].use(ga.run)),
+      RunIOToId,
+      RunKleisliWithNoopSpan,
       (routes, filter, ep) => routes.traced(Http4sResourceKleislis.fromHeaders(requestFilter = filter)(ep.toKleisli)),
       (app, filter, ep) => app.traced(Http4sResourceKleislis.fromHeaders(requestFilter = filter)(ep.toKleisli))
     )

--- a/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ServerCtxSyntaxSpec.scala
+++ b/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ServerCtxSyntaxSpec.scala
@@ -2,17 +2,14 @@ package io.janstenpickle.trace4cats.http4s.server
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.{Id, ~>}
-import io.janstenpickle.trace4cats.http4s.common.{RunIOToId, TraceContext}
-import io.janstenpickle.trace4cats.http4s.server.syntax.*
-import io.janstenpickle.trace4cats.http4s.server.Instances.*
+import io.janstenpickle.trace4cats.http4s.common.{RunIOToId, RunKleisliWithEmptyTraceContext, TraceContext}
+import io.janstenpickle.trace4cats.http4s.server.syntax._
+import io.janstenpickle.trace4cats.http4s.server.Instances._
 
 class ServerCtxSyntaxSpec
     extends BaseServerTracerSpec[IO, Kleisli[IO, TraceContext[IO], *]](
       RunIOToId,
-      new ~>[Kleisli[IO, TraceContext[IO], *], IO] {
-        override def apply[A](fa: Kleisli[IO, TraceContext[IO], A]): IO[A] = TraceContext.empty[IO].flatMap(fa.run)
-      },
+      RunKleisliWithEmptyTraceContext,
       (routes, filter, ep) => routes.injectContext(ep, makeContext = TraceContext.make[IO], requestFilter = filter),
       (app, filter, ep) => app.injectContext(ep, makeContext = TraceContext.make[IO], requestFilter = filter),
     )

--- a/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ServerCtxSyntaxSpec.scala
+++ b/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ServerCtxSyntaxSpec.scala
@@ -2,15 +2,17 @@ package io.janstenpickle.trace4cats.http4s.server
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.{~>, Id}
-import io.janstenpickle.trace4cats.http4s.common.TraceContext
-import io.janstenpickle.trace4cats.http4s.server.syntax._
-import io.janstenpickle.trace4cats.http4s.server.Instances._
+import cats.{Id, ~>}
+import io.janstenpickle.trace4cats.http4s.common.{RunIOToId, TraceContext}
+import io.janstenpickle.trace4cats.http4s.server.syntax.*
+import io.janstenpickle.trace4cats.http4s.server.Instances.*
 
 class ServerCtxSyntaxSpec
     extends BaseServerTracerSpec[IO, Kleisli[IO, TraceContext[IO], *]](
-      λ[IO ~> Id](_.unsafeRunSync()),
-      λ[Kleisli[IO, TraceContext[IO], *] ~> IO](ga => TraceContext.empty[IO].flatMap(ga.run)),
+      RunIOToId,
+      new ~>[Kleisli[IO, TraceContext[IO], *], IO] {
+        override def apply[A](fa: Kleisli[IO, TraceContext[IO], A]): IO[A] = TraceContext.empty[IO].flatMap(fa.run)
+      },
       (routes, filter, ep) => routes.injectContext(ep, makeContext = TraceContext.make[IO], requestFilter = filter),
       (app, filter, ep) => app.injectContext(ep, makeContext = TraceContext.make[IO], requestFilter = filter),
     )

--- a/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ServerSyntaxSpec.scala
+++ b/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ServerSyntaxSpec.scala
@@ -2,11 +2,9 @@ package io.janstenpickle.trace4cats.http4s.server
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.{Id, ~>}
 import io.janstenpickle.trace4cats.Span
 import io.janstenpickle.trace4cats.http4s.common.{RunIOToId, RunKleisliWithNoopSpan}
-import io.janstenpickle.trace4cats.http4s.server.Instances.*
-import io.janstenpickle.trace4cats.http4s.server.syntax.*
+import io.janstenpickle.trace4cats.http4s.server.syntax._
 
 class ServerSyntaxSpec
     extends BaseServerTracerSpec[IO, Kleisli[IO, Span[IO], *]](

--- a/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ServerSyntaxSpec.scala
+++ b/modules/http4s-server/src/test/scala/io/janstenpickle/trace4cats/http4s/server/ServerSyntaxSpec.scala
@@ -2,15 +2,16 @@ package io.janstenpickle.trace4cats.http4s.server
 
 import cats.data.Kleisli
 import cats.effect.IO
-import cats.{~>, Id}
+import cats.{Id, ~>}
 import io.janstenpickle.trace4cats.Span
-import io.janstenpickle.trace4cats.http4s.server.Instances._
-import io.janstenpickle.trace4cats.http4s.server.syntax._
+import io.janstenpickle.trace4cats.http4s.common.{RunIOToId, RunKleisliWithNoopSpan}
+import io.janstenpickle.trace4cats.http4s.server.Instances.*
+import io.janstenpickle.trace4cats.http4s.server.syntax.*
 
 class ServerSyntaxSpec
     extends BaseServerTracerSpec[IO, Kleisli[IO, Span[IO], *]](
-      λ[IO ~> Id](_.unsafeRunSync()),
-      λ[Kleisli[IO, Span[IO], *] ~> IO](ga => Span.noop[IO].use(ga.run)),
+      RunIOToId,
+      RunKleisliWithNoopSpan,
       (routes, filter, ep) => routes.inject(ep, requestFilter = filter),
       (app, filter, ep) => app.inject(ep, requestFilter = filter)
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,6 +4,7 @@ object Dependencies {
   object Versions {
     val scala212 = "2.12.14"
     val scala213 = "2.13.6"
+    val scala3 = "3.0.1"
 
     val trace4cats = "0.12.0-RC2"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     val scala213 = "2.13.6"
     val scala3 = "3.0.1"
 
-    val trace4cats = "0.12.0-RC2"
+    val trace4cats = "0.12.0-RC2+17-d73c7ff3"
 
     val catsEffect = "3.1.1"
     val http4s = "0.23.0-RC1"


### PR DESCRIPTION
Syntax fixes and extraction of FunctionK instances that are used several times to keep code DRY. Needs a Scala 3-published version of trace4cats core components, see https://github.com/trace4cats/trace4cats/pull/587