### PR TITLE
Allow to inject extra attributes

### DIFF
--- a/modules/http4s-common/src/main/scala/trace4cats/http4s/common/Http4sAttributes.scala
+++ b/modules/http4s-common/src/main/scala/trace4cats/http4s/common/Http4sAttributes.scala
@@ -1,10 +1,16 @@
 package trace4cats.http4s.common
 
+import cats.Eval
 import cats.effect.SyncIO
 import org.typelevel.vault.Key
+import trace4cats.model.AttributeValue
 
 object Http4sAttributes {
   object Keys {
     val SpanName: Key[String] = Key.newKey[SyncIO, String].unsafeRunSync()
+    val ExtraRequestAttributes: Key[Eval[Map[String, AttributeValue]]] =
+      Key.newKey[SyncIO, Eval[Map[String, AttributeValue]]].unsafeRunSync()
+    val ExtraResponseAttributes: Key[Eval[Map[String, AttributeValue]]] =
+      Key.newKey[SyncIO, Eval[Map[String, AttributeValue]]].unsafeRunSync()
   }
 }

--- a/modules/http4s-server/src/main/scala/trace4cats/http4s/server/ServerTracer.scala
+++ b/modules/http4s-server/src/main/scala/trace4cats/http4s/server/ServerTracer.scala
@@ -5,11 +5,12 @@ import cats.effect.kernel.MonadCancelThrow
 import cats.syntax.apply._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
+import cats.syntax.option._
 import cats.{FlatMap, Monad}
 import org.http4s.{HttpApp, HttpRoutes, Request, Response}
 import org.typelevel.ci.CIString
 import trace4cats.context.Provide
-import trace4cats.http4s.common.{Http4sHeaders, Http4sStatusMapping, Request_, Response_}
+import trace4cats.http4s.common.{Http4sAttributes, Http4sHeaders, Http4sStatusMapping, Request_, Response_}
 import trace4cats.{ResourceKleisli, Trace}
 
 object ServerTracer {
@@ -23,13 +24,19 @@ object ServerTracer {
         for {
           ctx <- P.ask[Ctx]
           _ <- Trace[G].putAll(Http4sHeaders.requestFields(req, dropHeadersWhen): _*)
+          _ <- Trace[G].putAll(
+            req.attributes.lookup(Http4sAttributes.Keys.ExtraRequestAttributes).map(_.value).orEmpty.toSeq: _*
+          )
           resp <-
             routes
               .run(req.mapK(P.liftK))
               .map(_.mapK(P.provideK(ctx)))
               .semiflatTap { res =>
                 Trace[G].setStatus(Http4sStatusMapping.toSpanStatus(res.status)) *>
-                  Trace[G].putAll(Http4sHeaders.responseFields(res, dropHeadersWhen): _*)
+                  Trace[G].putAll(Http4sHeaders.responseFields(res, dropHeadersWhen): _*) *>
+                  Trace[G].putAll(
+                    res.attributes.lookup(Http4sAttributes.Keys.ExtraResponseAttributes).map(_.value).orEmpty.toSeq: _*
+                  )
               }
               .value
         } yield resp
@@ -49,9 +56,15 @@ object ServerTracer {
         for {
           ctx <- P.ask[Ctx]
           _ <- Trace[G].putAll(Http4sHeaders.requestFields(req, dropHeadersWhen): _*)
+          _ <- Trace[G].putAll(
+            req.attributes.lookup(Http4sAttributes.Keys.ExtraRequestAttributes).map(_.value).orEmpty.toSeq: _*
+          )
           resp <- app.run(req.mapK(P.liftK)).map(_.mapK(P.provideK(ctx)))
           _ <- Trace[G].setStatus(Http4sStatusMapping.toSpanStatus(resp.status))
           _ <- Trace[G].putAll(Http4sHeaders.responseFields(resp, dropHeadersWhen): _*)
+          _ <- Trace[G].putAll(
+            resp.attributes.lookup(Http4sAttributes.Keys.ExtraResponseAttributes).map(_.value).orEmpty.toSeq: _*
+          )
         } yield resp
 
       k(req).use(P.provide(fa))


### PR DESCRIPTION
As both http4s' Request and Response have a Vault instance that allows to carry typed, arbitrary information, we can use this allow the injection of extra span attributes. Useful for example to set "peer.service" on individual requests.